### PR TITLE
Issue #63: Using renv to install all packages and dependencies used in eGRID

### DIFF
--- a/scripts/install_libraries.R
+++ b/scripts/install_libraries.R
@@ -25,4 +25,5 @@ for (package in required_packages) {
     install.packages(package, repos = "http://cran.us.r-project.org")
     require(package, character.only = TRUE)
   }
+  print("All required packages are installed.")
 }


### PR DESCRIPTION
This file was originally raising errors when attempting to use renv to download packages. I added a CRAN mirror to hopefully resolve these issues.  